### PR TITLE
v2.0.2 — helpful error when pg package is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-03-26
+
+### Fixed
+
+- Helpful error message when PostgreSQL backend is selected but the `pg`
+  package is not installed
+
 ## [2.0.1] - 2026-03-26
 
 ### Fixed
@@ -114,7 +121,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - JSON export/import for portability
 - Legacy JSON file migration path
 
-[Unreleased]: https://github.com/ealt/karya/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/ealt/karya/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/ealt/karya/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/ealt/karya/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/ealt/karya/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/ealt/karya/compare/v0.2.0...v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karya",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "SQL-backed task tracker for AI agent workflows",
   "type": "module",
   "license": "MIT",

--- a/src/core/create-backend.ts
+++ b/src/core/create-backend.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { DbBackend } from "./backend.js";
+import { KaryaError } from "./errors.js";
 import type { BackendConfig } from "./schema.js";
 
 export async function createBackend(config: BackendConfig): Promise<DbBackend> {
@@ -13,10 +14,19 @@ export async function createBackend(config: BackendConfig): Promise<DbBackend> {
     return new SqliteBackend(config.dbPath);
   }
 
-  const { createPool, PgBackend } = await import("./backends/pg.js");
-  const pool = await createPool(config.connectionString, {
+  let pgModule: typeof import("./backends/pg.js");
+  try {
+    pgModule = await import("./backends/pg.js");
+  } catch {
+    throw new KaryaError(
+      "PostgreSQL backend requires the 'pg' package. Install it with: npm install -g pg",
+      "CONFIG",
+    );
+  }
+
+  const pool = await pgModule.createPool(config.connectionString, {
     mode: config.ssl,
     caPath: config.sslCaPath,
   });
-  return new PgBackend(pool);
+  return new pgModule.PgBackend(pool);
 }


### PR DESCRIPTION
Catch the module-not-found error when the PostgreSQL backend is selected
but the `pg` peer dependency is not installed, and surface a clear
KaryaError instead of a cryptic ResolveMessage.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>